### PR TITLE
Gracefully handle EOF during seek on Google Cloud

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,5 +32,9 @@
 	
 
   </dependencies>
+
+    <build>
+        <sourceDirectory>src</sourceDirectory>
+    </build>
   <description>FASTdoop is a generic Apache Hadoop library for the management of FASTA and FASTQ files. It includes three input reader formats with associated record readers. These readers are optimized to read data efficiently from FASTA/FASTQ files in a variety of settings. Currently, FASTdoop supports FASTA files containing one or more short sequences (i.e., few hundreds of characters each) or a single very large sequence of arbitrary length (e.g. millions or billions of characters). Moreover, it allows to parse the content of FASTQ files containing short sequences. </description>
 </project>

--- a/src/fastdoop/FASTQReadsRecordReader.java
+++ b/src/fastdoop/FASTQReadsRecordReader.java
@@ -108,7 +108,7 @@ public class FASTQReadsRecordReader extends RecordReader<Text, QRecord> {
 		Path path = split.getPath();
 		startByte = split.getStart();
 		inputFile = path.getFileSystem(job).open(path);
-		inputFile.seek(startByte);
+		Utils.safeSeek(inputFile, startByte);
 
 		currKey = new Text("null");
 		currRecord = new QRecord();
@@ -124,7 +124,7 @@ public class FASTQReadsRecordReader extends RecordReader<Text, QRecord> {
 		borderBuffer = new byte[look_ahead_buffer_size];
 
 		sizeBuffer = inputFile.read(startByte, myInputSplitBuffer, 0, myInputSplitBuffer.length);
-		inputFile.seek(startByte + sizeBuffer);
+		Utils.safeSeek(inputFile,startByte + sizeBuffer);
 
 		if (inputFile.available() == 0) {
 			isLastSplit = true;

--- a/src/fastdoop/ShortReadsRecordReader.java
+++ b/src/fastdoop/ShortReadsRecordReader.java
@@ -114,7 +114,7 @@ public class ShortReadsRecordReader extends RecordReader<Text, Record> {
 		Path path = split.getPath();
 		startByte = split.getStart();
 		inputFile = path.getFileSystem(job).open(path);
-		inputFile.seek(startByte);
+		Utils.safeSeek(inputFile, startByte);
 
 		currKey = new Text("null");
 		currValue = new Record();
@@ -131,7 +131,7 @@ public class ShortReadsRecordReader extends RecordReader<Text, Record> {
 		borderBuffer = new byte[look_ahead_buffer_size];
 
 		sizeBuffer = inputFile.read(startByte, myInputSplitBuffer, 0, myInputSplitBuffer.length);
-		inputFile.seek(startByte + sizeBuffer);
+		Utils.safeSeek(inputFile, startByte + sizeBuffer);
 
 		if (sizeBuffer <= 0) {
 			endMyInputSplit = true;

--- a/src/fastdoop/Utils.java
+++ b/src/fastdoop/Utils.java
@@ -1,0 +1,44 @@
+package fastdoop;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+class Utils {
+
+    /**
+     * From FSUtils in HUDI https://github.com/apache/hudi
+     * <p>
+     * GCS has a different behavior for detecting EOF during seek().
+     *
+     * @param inputStream FSDataInputStream
+     * @return true if the inputstream or the wrapped one is of type GoogleHadoopFSInputStream
+     */
+    public static boolean isGCSInputStream(FSDataInputStream inputStream) {
+        return inputStream.getClass().getCanonicalName().equals("com.google.cloud.hadoop.fs.gcs.GoogleHadoopFSInputStream")
+                || inputStream.getWrappedStream().getClass().getCanonicalName()
+                .equals("com.google.cloud.hadoop.fs.gcs.GoogleHadoopFSInputStream");
+    }
+
+
+    /**
+     * From FSUtils in HUDI https://github.com/apache/hudi
+     *
+     * Handles difference in seek behavior for GCS and non-GCS input stream
+     * @param inputStream Input Stream
+     * @param pos  Position to seek
+     * @throws IOException
+     */
+    public static void safeSeek(FSDataInputStream inputStream, long pos) throws IOException {
+        try {
+            inputStream.seek(pos);
+        } catch (EOFException e) {
+            if (isGCSInputStream(inputStream)) {
+                inputStream.seek(pos - 1);
+            } else {
+                throw e;
+            }
+        }
+    }
+}


### PR DESCRIPTION
I found that Fastdoop wouldn't work on GCP due to EOF handling. This change solves the issue and should have no effect on other platforms.