### PR TITLE
Bugfix for handling of terminator characters like \n and + at the end of splits

### DIFF
--- a/src/fastdoop/FASTQReadsRecordReader.java
+++ b/src/fastdoop/FASTQReadsRecordReader.java
@@ -212,9 +212,11 @@ public class FASTQReadsRecordReader extends RecordReader<Text, QRecord> {
 			 * Assuming there are more characters from the current split to
 			 * process, we move forward the pointer
 			 * until the symbol '+' is found
+			 *
+			 * posBuffer + 1 can potentially overrun the buffer end, since the exception above is not thrown
+			 * if the final character of the split is a \n. Check the offset accordingly.
 			 */
-
-			currRecord.setStartValue(posBuffer + 1);
+			currRecord.setStartValue(Utils.trimToEnd(myInputSplitBuffer, posBuffer + 1));
 
 			try {
 				posBuffer = posBuffer + 2;
@@ -261,7 +263,9 @@ public class FASTQReadsRecordReader extends RecordReader<Text, QRecord> {
 
 		if (!endMyInputSplit) {
 
-			currRecord.setStartKey2(posBuffer);
+			//The exception above would not be thrown if the final character of the split is a +.
+			//Check the offset accordingly.
+			currRecord.setStartKey2(Utils.trimToEnd(myInputSplitBuffer, posBuffer));
 
 			try {
 
@@ -291,7 +295,9 @@ public class FASTQReadsRecordReader extends RecordReader<Text, QRecord> {
 
 				if (!endMyInputSplit) {
 
-					currRecord.setStartQuality(posBuffer + 1);
+					//The exception above would not be thrown if the final character of the split is a newline.
+					//Check the offset accordingly.
+					currRecord.setStartQuality(Utils.trimToEnd(myInputSplitBuffer, posBuffer + 1));
 					currRecord.setEndQuality(currRecord.getStartQuality() + currRecord.getEndValue() - currRecord.getStartValue());
 					posBuffer = (currRecord.getEndQuality() + 3);
 

--- a/src/fastdoop/ShortReadsRecordReader.java
+++ b/src/fastdoop/ShortReadsRecordReader.java
@@ -195,8 +195,11 @@ public class ShortReadsRecordReader extends RecordReader<Text, Record> {
 			 * Assuming there are more characters from the current split to
 			 * process, we move forward the pointer
 			 * until the symbol '>' is found
+			 *
+			 * posBuffer + 1 can potentially overrun the end of the buffer, since the exception above
+			 * would not be thrown if the final character of the split is a \n. Check the offset accordingly.
 			 */
-			currValue.setStartValue(posBuffer + 1);
+			currValue.setStartValue(Utils.trimToEnd(myInputSplitBuffer, posBuffer + 1));
 
 			try {
 				while (myInputSplitBuffer[posBuffer] != '>') {

--- a/src/fastdoop/Utils.java
+++ b/src/fastdoop/Utils.java
@@ -41,4 +41,14 @@ class Utils {
             }
         }
     }
+
+    /**
+     * Adjust an offset into a buffer such that the offset does not overrun the buffer end.
+     * @param buffer
+     * @param offset
+     * @return
+     */
+    public static int trimToEnd(byte[] buffer, int offset) {
+        return (offset <= buffer.length - 1) ? offset : (buffer.length - 1);
+    }
 }


### PR DESCRIPTION
Hi,

I fixed a bug in Fastdoop and thought you might potentially be interested. 
When precisely the final character of a split is a delimiter like \n or +, sometimes buffer offsets that exceed the length of myInputSplitBuffer would potentially be set in Record or QRecord, since end of split would not be detected properly.
Subsequent calls to methods like Record.getValue would then throw an exception, because the String they construct would not be valid.

I attach my suggested fix, but I do not fully understand all the details of Fastdoop, so you may want to do additional testing. Unfortunately a corner case like this is probably tricky to catch as it depends on the sizes of splits.
I verified that the fix solves the bug for me in ShortReadsRecordReader, and since I saw a similar code pattern in FASTQReadsRecordReader I corrected it there too. However, I currently have no way of producing buggy behaviour (which I think should in theory be there) for FASTQ records, so for that class I have only verified that this change does not break anything.

See what you think.
Best wishes
