### PR TITLE
Fix header parsing for FASTQ splits where quality ends in '@'

### DIFF
--- a/src/main/java/fastdoop/FASTQReadsRecordReader.java
+++ b/src/main/java/fastdoop/FASTQReadsRecordReader.java
@@ -161,7 +161,7 @@ public class FASTQReadsRecordReader extends RecordReader<Text, QRecord> {
 		/*
 		 * We skip the first header of the split
 		 */
-		int j = posBuffer + 1;
+		int j = posBuffer;
 
 		while (myInputSplitBuffer[j] != '\n') {
 			j++;
@@ -169,7 +169,6 @@ public class FASTQReadsRecordReader extends RecordReader<Text, QRecord> {
 
 		if (myInputSplitBuffer[j + 1] == '@')
 			posBuffer = j + 2;
-
 	}
 
 	@Override


### PR DESCRIPTION
Hello,

I found a minor bug in fastq parsing that this PR fixes.
Consider the case where the final character of a quality string is an '@', as in the following record.

```
@ERR599052.73 H6:C16GEACXX:4:1101:2254:2163 length=101
ACACTATTATATACTCATTATTTATTTAATATATTTGTATTATTACAATTAAATGTTCTATAAAGTGTTTTTTTTCGTAGTATTAGGTACAGTTAAAAATA
+ERR599052.73 H6:C16GEACXX:4:1101:2254:2163 length=101
@@@FFFFFHHHFHJJIGHJIJJJJJJJGGHGIIIJJIHHIJIHIJJJJJIJIEGIGIIJJIIJIIDGBBFHIIIHFHFFFDEEEFED>CCDD@CCDDDDD@
```

If a split begins on the final @ character of this record, in the quality string, then the reader's initialize() method will try to seek to the next header (line 148). However, it would find the '@' at position i (== 0), set posBuffer to i+1 (\n), and then set j to posBuffer+1 (the @ marking the start of the next header). It will then proceed to seek past the header it was trying to find in the newline finding loop. (Line 166)

This issue was leading to data loss, as some sequence data was never returned as part of a QRecord.

By setting j to posBuffer instead of posBuffer + 1, the loop that searches for \n will succeed in such a case, and then no data is lost. This change shouldn't affect any other cases.


